### PR TITLE
Fixed overflow on ride details page by adding scrolling

### DIFF
--- a/app/src/main/res/layout/card_ride_request_detail.xml
+++ b/app/src/main/res/layout/card_ride_request_detail.xml
@@ -9,11 +9,11 @@
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
         android:text="TITLE:"
-        android:textSize="14dp"/>
+        android:textSize="14sp"/>
     <TextView
         android:id="@+id/request_detail_value"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="VALUE"
-        android:textSize="16dp"/>
+        android:textSize="16sp"/>
 </LinearLayout>


### PR DESCRIPTION
This does not pin buttons to the bottom anymore when it doesnt overflow: this is a limitation of using scrollviews